### PR TITLE
Fix build errors caused by missing cassert import and virtual overload

### DIFF
--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -15,6 +15,14 @@
 #ifndef RAPIDJSON_RAPIDJSON_H_
 #define RAPIDJSON_RAPIDJSON_H_
 
+#ifdef __clang__
+#   ifdef __ICC // icpc defines the __clang__ macro
+#   else // __ICC
+#       pragma clang diagnostic ignored "-Wc++98-compat"
+#       pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#    endif
+#endif
+
 /*!\file rapidjson.h
     \brief common definitions and configuration
     
@@ -401,10 +409,17 @@ RAPIDJSON_NAMESPACE_END
 // #include <cassert>
 // #define RAPIDJSON_ASSERT(x) assert(x)
 #include <stdexcept>
+#include <cassert>
 class rapidjson_exception : public std::runtime_error {
  public:
   rapidjson_exception() : std::runtime_error("json schema invalid") {}
+  char const * what() const _NOEXCEPT;
 };
+
+char const * rapidjson_exception::what() const _NOEXCEPT {
+  return "json schema invalid";
+}
+
 #define RAPIDJSON_ASSERT(x) { if(x); else throw rapidjson_exception(); }
 #endif // RAPIDJSON_ASSERT
 


### PR DESCRIPTION
The removal of the `cassert` import in `rapidjson.h` resulted in build errors with the library's included tutorial. Additionally, there was a missing overload of the virtual `const char* what() const noexcept` function in the `rapidjson_exception` class, which inherits from `std::runtime_error`. In order to overload this method properly, the `noexcept` modifier must be used. To achieve this, C++98 compatibility checks have been disabled via a pragma at the top of `rapidjson.h`. Everything is building properly now. 